### PR TITLE
JSonnet Example #1 - Configmap with envsubst

### DIFF
--- a/.github/workflows/03-release-manifests.yaml
+++ b/.github/workflows/03-release-manifests.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: kingdonb/kubecfg/action@main
 
       - name: kubecfg show
-        run: kubecfg show manifests/example.jsonnet > output/production.yaml
+        run: ./ci/kubecfg.sh VERSION=${VERSION}
 
       - name: Prepare target branch
         run: ./ci/rake.sh deploy

--- a/.github/workflows/03-release-manifests.yaml
+++ b/.github/workflows/03-release-manifests.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: kingdonb/kubecfg/action@main
 
       - name: kubecfg show
-        run: ./ci/kubecfg.sh VERSION=${VERSION}
+        run: "./ci/kubecfg.sh VERSION=${{ steps.prep.outputs.VERSION }}"
 
       - name: Prepare target branch
         run: ./ci/rake.sh deploy

--- a/ci/kubecfg.sh
+++ b/ci/kubecfg.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# ./ci/kubecfg.sh
+set -feux   # Usage: $0 VERSION=<VERSION>   # Fails when VERSION is not provided
+VERSION_VAR_SETTER="$1"
+
+kubecfg show \
+	-V $VERSION_VAR_SETTER \
+	manifests/example.jsonnet > output/production.yaml

--- a/flux-config/app-version-configmap.yaml
+++ b/flux-config/app-version-configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  GIT_SHA: 19d5b7ef
+  GIT_SHA: df3df954
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/k8s.yml
+++ b/k8s.yml
@@ -13,7 +13,7 @@ spec:
         app: any-old-app
     spec:
       containers:
-      - image: kingdonb/any-old-app:19d5b7ef
+      - image: kingdonb/any-old-app:df3df954
         name: any-old-app
 
 ---

--- a/manifests/example.jsonnet
+++ b/manifests/example.jsonnet
@@ -37,6 +37,9 @@ local example = import 'example.libsonnet';
 
 {
   version_configmap: kube.ConfigMap('any-old-app-version') {
+    metadata+: {
+      namespace: 'prod-yebyen',
+    },
     data+: {
       VERSION: 'v1.0.0',
     },

--- a/manifests/example.jsonnet
+++ b/manifests/example.jsonnet
@@ -38,7 +38,7 @@ local example = import 'example.libsonnet';
 {
   version_configmap: kube.ConfigMap('any-old-app-version') {
     metadata+: {
-      namespace: 'prod-yebyen',
+      namespace: 'yebyen-okd4',
     },
     data+: {
       VERSION: 'v1.0.0',

--- a/manifests/example.jsonnet
+++ b/manifests/example.jsonnet
@@ -41,7 +41,7 @@ local example = import 'example.libsonnet';
       namespace: 'yebyen-okd4',
     },
     data+: {
-      VERSION: 'v0.10.0-beta4',
+      VERSION: '0.10.0-beta4',
     },
   },
   flux_kustomization: example.kustomization('any-old-app-prod') {

--- a/manifests/example.jsonnet
+++ b/manifests/example.jsonnet
@@ -41,7 +41,7 @@ local example = import 'example.libsonnet';
       namespace: 'yebyen-okd4',
     },
     data+: {
-      VERSION: '0.10.1-beta4',
+      VERSION: std.extVar('VERSION'),
     },
   },
   flux_kustomization: example.kustomization('any-old-app-prod') {

--- a/manifests/example.jsonnet
+++ b/manifests/example.jsonnet
@@ -41,7 +41,7 @@ local example = import 'example.libsonnet';
       namespace: 'yebyen-okd4',
     },
     data+: {
-      VERSION: 'v1.0.0',
+      VERSION: 'v0.10.0-beta4',
     },
   },
   flux_kustomization: example.kustomization('any-old-app-prod') {

--- a/manifests/example.jsonnet
+++ b/manifests/example.jsonnet
@@ -41,7 +41,7 @@ local example = import 'example.libsonnet';
       namespace: 'yebyen-okd4',
     },
     data+: {
-      VERSION: '0.10.0-beta4',
+      VERSION: '0.10.1-beta4',
     },
   },
   flux_kustomization: example.kustomization('any-old-app-prod') {


### PR DESCRIPTION
The first example from the Jsonnet stdlib is `std.extVar(x)`: https://jsonnet.org/ref/stdlib.html#ext_vars

We should make that our first Jsonnet example, too. Tagged as 0.10.1, this can be referred to as Example 10.1 in future docs, (in case this example app repo should turn out to be expanding to fill out future docs too.)

Confirmed to work in https://github.com/kingdonb/any_old_app/commit/ad21d55b3f354f57d9d5f47e177e07b92ac16443 which was tagged as `release/0.10.1-beta8`: https://github.com/kingdonb/any_old_app/tree/release/0.10.1-beta8

I'll also tag this as https://github.com/kingdonb/any_old_app/tree/release/0.10.1 once it has merged.

The intention is to allow people to navigate to an example in context, since certain example use cases might require files like `.github/workflows/03-release-manifests.yaml` to change in orthogonal or totally opposite ways.

This way each released example carries with it a context and can be tested, showing that the example works. (The alpha and beta releases for this example were a bit spammy while I figured out how to work this machine. Apologies for that.)